### PR TITLE
Fix dropout param bug in SimpleMLP usage

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ if __name__ == "__main__":
     input_dim    = 28 * 28
     hidden_dims  = [128, 64]
     output_dim   = 1
+    dropout_rate = 0.2
     lr           = 1e-3
     epochs       = 100
     val_fraction = 0.2 
@@ -37,7 +38,7 @@ if __name__ == "__main__":
     val_loader   = DataLoader(val_ds,   batch_size=batch_size, shuffle=False)
 
     # model, optimizer, loss function
-    model     = SimpleMLP(input_dim, hidden_dims, output_dim).to(device)
+    model     = SimpleMLP(input_dim, hidden_dims, output_dim, dropout_rate).to(device)
     optimizer = optim.Adam(model.parameters(), lr=lr)
     criterion = MSELoss()
 


### PR DESCRIPTION
## Summary
- pass `dropout_rate` when creating `SimpleMLP`
- add a `dropout_rate` hyperparameter in `main.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_684afdb40d3483339524e7f6d9fcaba0